### PR TITLE
fix canvas' setScaling syscall

### DIFF
--- a/devices/canvas.js
+++ b/devices/canvas.js
@@ -81,7 +81,7 @@ class Canvas extends Device{
       this.imageData = this.ctx.createImageData(reg.a0, reg.a1);
     }.bind(this));
     this.registerSyscall(2202, "Canvas setScaling", syscall, function (reg) {
-      this.ctx.scale(reg.a0, reg.a1);
+      this.imageData = this.scaleImageData(this.imageData, reg.a0, reg.a1);
     }.bind(this));
 
     this.bus.watchAddress(this.base_addr, function (value) {
@@ -93,6 +93,33 @@ class Canvas extends Device{
       }
       this.bus.mmio.store(this.base_addr, 1, 0);
     }.bind(this), 1, 1);
+  }
+
+  scaleImageData(imageData, scaleX, scaleY) {
+    // Create a temporary canvas to hold the original ImageData
+    const tempCanvas = document.createElement('canvas');
+    const tempCtx = tempCanvas.getContext('2d');
+    
+    // Set the temporary canvas dimensions to match the ImageData
+    tempCanvas.width = imageData.width;
+    tempCanvas.height = imageData.height;
+    
+    // Put the original ImageData onto the temporary canvas
+    tempCtx.putImageData(imageData, 0, 0);
+    
+    // Create a new canvas with scaled dimensions
+    const scaledCanvas = document.createElement('canvas');
+    const scaledCtx = scaledCanvas.getContext('2d');
+    
+    // Set the new canvas dimensions to the scaled size
+    scaledCanvas.width = imageData.width * scaleX;
+    scaledCanvas.height = imageData.height * scaleY;
+    
+    // Use drawImage to scale the temporary canvas content onto the new canvas
+    scaledCtx.drawImage(tempCanvas, 0, 0, imageData.width, imageData.height, 0, 0, scaledCanvas.width, scaledCanvas.height);
+    
+    // Get the scaled ImageData from the new canvas
+    return scaledCtx.getImageData(0, 0, scaledCanvas.width, scaledCanvas.height);
   }
 }
 


### PR DESCRIPTION
Previous setScaling syscall did not perform scaling of the image.
This new implementation sets the scale for the image, and **must be called after setting all pixels of the image**. Its primary use would be to help the students in spotting misplaced pixels.

Some examples are shown below.

- **No Scaling**
  ![image](https://github.com/user-attachments/assets/c56dc4ec-442b-4422-a7a9-cb143c1cb62e)

- **Scaling a0 = 1, a1 = 5**
  ![image](https://github.com/user-attachments/assets/be68f8dc-5683-473c-8b73-fde4868f9b51)

- **Scaling a0 = 5, a1 = 1**
  ![image](https://github.com/user-attachments/assets/5decb61c-30d0-45b6-9bde-df1d0e0070cf)

- **Scaling a0 = 5, a1 = 5**
  ![image](https://github.com/user-attachments/assets/180f2d1a-adf2-41f7-bb3e-8fbbf721e27a)


- **Scaling a0 = 10, a1 = 10**
  ![image](https://github.com/user-attachments/assets/9eb6a775-0dda-4f23-9782-131ba47f34d4)